### PR TITLE
[Product] : 상품 Controller 및 RequestDto, ResponseDto

### DIFF
--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     compileOnly 'org.projectlombok:lombok'
+    implementation "org.mapstruct:mapstruct:1.5.5.Final"
+    annotationProcessor "org.mapstruct:mapstruct-processor:1.5.5.Final"
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/product-service/src/main/java/com/oingmaryho/business/productservice/ProductServiceApplication.java
+++ b/product-service/src/main/java/com/oingmaryho/business/productservice/ProductServiceApplication.java
@@ -2,8 +2,10 @@ package com.oingmaryho.business.productservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class ProductServiceApplication {
 
     public static void main(String[] args) {

--- a/product-service/src/main/java/com/oingmaryho/business/productservice/application/ProductApplicationMapper.java
+++ b/product-service/src/main/java/com/oingmaryho/business/productservice/application/ProductApplicationMapper.java
@@ -1,0 +1,17 @@
+package com.oingmaryho.business.productservice.application;
+
+import org.mapstruct.Mapper;
+
+import com.oingmaryho.business.productservice.application.dto.request.ProductDetailsSearchRequestServiceDto;
+import com.oingmaryho.business.productservice.application.dto.response.ProductDetailsSearchResponseServiceDto;
+import com.oingmaryho.business.productservice.domain.Product;
+
+@Mapper(componentModel = "spring")
+public interface ProductApplicationMapper {
+
+	// in : application request dto -> entity
+	Product toProduct(ProductDetailsSearchRequestServiceDto productServiceDto);
+
+	// out : entity -> application response dto
+	ProductDetailsSearchResponseServiceDto toResponseDto(Product product);
+}

--- a/product-service/src/main/java/com/oingmaryho/business/productservice/application/ProductService.java
+++ b/product-service/src/main/java/com/oingmaryho/business/productservice/application/ProductService.java
@@ -1,0 +1,24 @@
+package com.oingmaryho.business.productservice.application;
+
+import org.springframework.stereotype.Service;
+
+import com.oingmaryho.business.productservice.application.dto.request.ProductDetailsSearchRequestServiceDto;
+import com.oingmaryho.business.productservice.application.dto.response.ProductDetailsSearchResponseServiceDto;
+import com.oingmaryho.business.productservice.domain.Product;
+import com.oingmaryho.business.productservice.domain.repository.ProductRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+	private final ProductRepository productRepository;
+	private final ProductApplicationMapper productApplicationMapper;
+
+	public ProductDetailsSearchResponseServiceDto getProductDetails(ProductDetailsSearchRequestServiceDto requestDto) {
+		Product product = productRepository.findByIdAndIsDeletedFalse(requestDto.id())
+			.orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다: " + requestDto.id()));
+
+		return productApplicationMapper.toResponseDto(product);
+	}
+}

--- a/product-service/src/main/java/com/oingmaryho/business/productservice/application/dto/request/ProductDetailsSearchRequestServiceDto.java
+++ b/product-service/src/main/java/com/oingmaryho/business/productservice/application/dto/request/ProductDetailsSearchRequestServiceDto.java
@@ -1,0 +1,8 @@
+package com.oingmaryho.business.productservice.application.dto.request;
+
+import java.util.UUID;
+
+public record ProductDetailsSearchRequestServiceDto(
+	UUID id
+) {
+}

--- a/product-service/src/main/java/com/oingmaryho/business/productservice/application/dto/response/ProductDetailsSearchResponseServiceDto.java
+++ b/product-service/src/main/java/com/oingmaryho/business/productservice/application/dto/response/ProductDetailsSearchResponseServiceDto.java
@@ -1,0 +1,13 @@
+package com.oingmaryho.business.productservice.application.dto.response;
+
+import java.util.UUID;
+
+public record ProductDetailsSearchResponseServiceDto(
+	UUID id,
+	String name,
+	UUID companyId,
+	UUID manageHubId,
+	Integer price,
+	Integer stock
+) {
+}

--- a/product-service/src/main/java/com/oingmaryho/business/productservice/config/JpaAuditingConfig.java
+++ b/product-service/src/main/java/com/oingmaryho/business/productservice/config/JpaAuditingConfig.java
@@ -1,0 +1,39 @@
+package com.oingmaryho.business.productservice.config;
+
+import java.util.Optional;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+
+	@Bean
+	public AuditorAware<Long> auditorProvider() {
+		return () -> {
+			ServletRequestAttributes attributes =
+				(ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+			if (attributes == null) {
+				return Optional.empty();
+			}
+
+			String userId = attributes.getRequest().getHeader("userId");
+
+			if (userId != null) {
+				try {
+					return Optional.of(Long.parseLong(userId));
+				} catch (NumberFormatException e) {
+					return Optional.empty();
+				}
+			}
+
+			return Optional.empty();
+		};
+	}
+}

--- a/product-service/src/main/java/com/oingmaryho/business/productservice/config/pageable/PageableConfig.java
+++ b/product-service/src/main/java/com/oingmaryho/business/productservice/config/pageable/PageableConfig.java
@@ -1,0 +1,51 @@
+package com.oingmaryho.business.productservice.config.pageable;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+
+@Configuration
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
+public class PageableConfig implements WebMvcConfigurer {
+	private static final int DEFAULT_SIZE = 10;
+	private static final String DEFAULT_SORT_DIRECTION = "desc";
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		PageableHandlerMethodArgumentResolver resolver = new PageableHandlerMethodArgumentResolver();
+		resolver.setFallbackPageable(PageRequest.of(0, 10, ascSort()));
+		resolvers.add(resolver);
+	}
+
+	public Pageable customPageable(Integer page, Integer size, String sortDirection) {
+		int currentPage = (page != null && page > 0) ? page - 1 : 0;
+		int currentSize = (size != null) ? size : DEFAULT_SIZE;
+		String currentSortDirection = (sortDirection != null) ? sortDirection.toLowerCase() : DEFAULT_SORT_DIRECTION;
+
+		Sort sort = DEFAULT_SORT_DIRECTION.equalsIgnoreCase(currentSortDirection) ? DescSort() : ascSort();
+		return PageRequest.of(currentPage, currentSize, sort);
+	}
+
+	public Sort ascSort() {
+		return Sort.by(
+			Sort.Order.asc(SortConstants.CREATED_AT),
+			Sort.Order.asc(SortConstants.UPDATED_AT)
+		);
+	}
+
+	public Sort DescSort() {
+		return Sort.by(
+			Sort.Order.desc(SortConstants.CREATED_AT),
+			Sort.Order.desc(SortConstants.UPDATED_AT)
+		);
+	}
+
+}

--- a/product-service/src/main/java/com/oingmaryho/business/productservice/config/pageable/SortConstants.java
+++ b/product-service/src/main/java/com/oingmaryho/business/productservice/config/pageable/SortConstants.java
@@ -1,0 +1,6 @@
+package com.oingmaryho.business.productservice.config.pageable;
+
+public class SortConstants {
+	public static final String CREATED_AT = "createdAt";
+	public static final String UPDATED_AT = "updatedAt";
+}

--- a/product-service/src/main/java/com/oingmaryho/business/productservice/domain/BaseEntity.java
+++ b/product-service/src/main/java/com/oingmaryho/business/productservice/domain/BaseEntity.java
@@ -1,0 +1,44 @@
+package com.oingmaryho.business.productservice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@SuperBuilder
+@MappedSuperclass
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+	@Column(updatable = false)
+	private Long deletedBy;
+
+	@Column(updatable = false)
+	@Temporal(TemporalType.TIMESTAMP)
+	private LocalDateTime deletedAt;
+
+	@CreatedDate
+	@Column(updatable = false)
+	@Temporal(TemporalType.TIMESTAMP)
+	private LocalDateTime createdAt;
+
+	@CreatedBy
+	@Column(updatable = false)
+	private Long createdBy;
+
+	@LastModifiedDate
+	@Column
+	@Temporal(TemporalType.TIMESTAMP)
+	private LocalDateTime updatedAt;
+
+	@LastModifiedBy
+	private Long updatedBy;
+}

--- a/product-service/src/main/java/com/oingmaryho/business/productservice/domain/Product.java
+++ b/product-service/src/main/java/com/oingmaryho/business/productservice/domain/Product.java
@@ -1,0 +1,48 @@
+package com.oingmaryho.business.productservice.domain;
+
+import java.util.UUID;
+
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@SuperBuilder
+@DynamicInsert
+@DynamicUpdate
+@Table(name = "p_product")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
+
+	@Column(nullable = false)
+	private UUID companyId;
+
+	@Column(nullable = false)
+	private String name;
+
+	@Column(nullable = false)
+	private UUID manageHubId;
+
+	@Column(nullable = false)
+	private Long stock;
+
+	@Column(nullable = false)
+	private Integer price;
+
+	@Column(nullable = false)
+	private Boolean isDeleted;
+}

--- a/product-service/src/main/java/com/oingmaryho/business/productservice/domain/repository/ProductRepository.java
+++ b/product-service/src/main/java/com/oingmaryho/business/productservice/domain/repository/ProductRepository.java
@@ -1,0 +1,13 @@
+package com.oingmaryho.business.productservice.domain.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import com.oingmaryho.business.productservice.domain.Product;
+
+@Repository
+public interface ProductRepository {
+	Optional<Product> findByIdAndIsDeletedFalse(UUID id);
+}

--- a/product-service/src/main/java/com/oingmaryho/business/productservice/domain/repository/ProductRepositoryImpl.java
+++ b/product-service/src/main/java/com/oingmaryho/business/productservice/domain/repository/ProductRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.oingmaryho.business.productservice.domain.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import com.oingmaryho.business.productservice.domain.Product;
+import com.oingmaryho.business.productservice.infrastructure.ProductJpaRepository;
+
+@Repository
+public class ProductRepositoryImpl implements ProductRepository {
+
+	private final ProductJpaRepository productJpaRepository;
+
+	public ProductRepositoryImpl(ProductJpaRepository productJpaRepository) {
+		this.productJpaRepository = productJpaRepository;
+	}
+
+	@Override
+	public Optional<Product> findByIdAndIsDeletedFalse(UUID id) {
+		return productJpaRepository.findByIdAndIsDeletedFalse(id);
+	}
+}

--- a/product-service/src/main/java/com/oingmaryho/business/productservice/infrastructure/ProductJpaRepository.java
+++ b/product-service/src/main/java/com/oingmaryho/business/productservice/infrastructure/ProductJpaRepository.java
@@ -1,0 +1,11 @@
+package com.oingmaryho.business.productservice.infrastructure;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.oingmaryho.business.productservice.domain.Product;
+
+public interface ProductJpaRepository extends JpaRepository<Product, UUID> {
+	Optional<Product> findByIdAndIsDeletedFalse(UUID id);
+}

--- a/product-service/src/main/java/com/oingmaryho/business/productservice/infrastructure/ProductQueryDslRepository.java
+++ b/product-service/src/main/java/com/oingmaryho/business/productservice/infrastructure/ProductQueryDslRepository.java
@@ -1,0 +1,7 @@
+package com.oingmaryho.business.productservice.infrastructure;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ProductQueryDslRepository {
+}

--- a/product-service/src/main/java/com/oingmaryho/business/productservice/presentation/ProductFeignClientController.java
+++ b/product-service/src/main/java/com/oingmaryho/business/productservice/presentation/ProductFeignClientController.java
@@ -1,0 +1,34 @@
+package com.oingmaryho.business.productservice.presentation;
+
+import java.util.UUID;
+
+import org.springframework.context.annotation.Description;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.oingmaryho.business.productservice.application.ProductService;
+import com.oingmaryho.business.productservice.application.dto.request.ProductDetailsSearchRequestServiceDto;
+import com.oingmaryho.business.productservice.application.dto.response.ProductDetailsSearchResponseServiceDto;
+import com.oingmaryho.business.productservice.presentation.dto.response.ProductDetailsSearchResponseDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping
+public class ProductFeignClientController {
+	private final ProductService productService;
+	private final ProductPresentationMapper productPresentationMapper;
+
+	@Description("FeignClient - 상품 상세 조회")
+	@GetMapping("/product-service/products/{id}")
+	public ResponseEntity<ProductDetailsSearchResponseDto> getProductById(@PathVariable UUID id) {
+		ProductDetailsSearchRequestServiceDto requestServiceDto = productPresentationMapper.toProductServiceDto(id);
+		ProductDetailsSearchResponseServiceDto responseServiceDto = productService.getProductDetails(requestServiceDto);
+		ProductDetailsSearchResponseDto response = productPresentationMapper.toProductDto(responseServiceDto);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/product-service/src/main/java/com/oingmaryho/business/productservice/presentation/ProductPresentationMapper.java
+++ b/product-service/src/main/java/com/oingmaryho/business/productservice/presentation/ProductPresentationMapper.java
@@ -1,0 +1,18 @@
+package com.oingmaryho.business.productservice.presentation;
+
+import java.util.UUID;
+
+import org.mapstruct.Mapper;
+
+import com.oingmaryho.business.productservice.application.dto.request.ProductDetailsSearchRequestServiceDto;
+import com.oingmaryho.business.productservice.application.dto.response.ProductDetailsSearchResponseServiceDto;
+import com.oingmaryho.business.productservice.presentation.dto.response.ProductDetailsSearchResponseDto;
+
+@Mapper(componentModel = "spring")
+public interface ProductPresentationMapper {
+	// in : presentation request -> service request
+	ProductDetailsSearchRequestServiceDto toProductServiceDto(UUID id);
+
+	// out : service response -> presentation response
+	ProductDetailsSearchResponseDto toProductDto(ProductDetailsSearchResponseServiceDto productServiceDto);
+}

--- a/product-service/src/main/java/com/oingmaryho/business/productservice/presentation/dto/response/ProductDetailsSearchResponseDto.java
+++ b/product-service/src/main/java/com/oingmaryho/business/productservice/presentation/dto/response/ProductDetailsSearchResponseDto.java
@@ -1,0 +1,13 @@
+package com.oingmaryho.business.productservice.presentation.dto.response;
+
+import java.util.UUID;
+
+public record ProductDetailsSearchResponseDto(
+	UUID id,
+	String name,
+	UUID companyId,
+	UUID manageHubId,
+	Integer price,
+	Integer stock
+) {
+}


### PR DESCRIPTION
## PR Type
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Summary : 변경 내용
- **as-is**

- **to-be**
  - feign client 를 위한 단건 조회 api 추가

## Issue Number
- close #73 

## Etc
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항
feign client에서 필요로 하는 field는 상품의 id랑 name 정도인데
일반적인 상품의 단건을 조회하는 경우에는 더 많은 필드들이 포함되어 있습니다.
이와 관련해서 dto를 새롭게 정의하는게 나을지 아니면 feignclient와 일반 동일하게 반환해주는게 좋을지 고민입니다...
(이부분에 추가로, admin의 경우에는 createdAt, createdBy와 같은 다른 일반 사용자들이 조회할 필요없는 필드들도 가지게 될 것 같은데, 그러면 이것까지 고려해 총 3종류의 dto가 나오는게 맞는지 아니면 모든 것을 다 반환해주는게 맞는지 고민이 되네요)